### PR TITLE
Ability to add additional plist files

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,12 @@ cli.version(projectVersion, '-v, --version')
 		'-i, --ios',
 		'Sync package version to ios.  It will not update Android, unless --android is specified.',
 		false
-	);
+	)
+	.option(
+		'-plist, --plist [files...]',
+		'Add additional plists to modify (ios only)',
+		false
+	)
 
 cli.on('--help', () => {
 	console.log(
@@ -50,13 +55,23 @@ async function main(cli) {
 	const packageVersion = projectPackageJson.version;
 
 	logger.log('Updating capacitor project versions to: ', packageVersion);
-
+	logger.log('sync android versions? ', cli.android || false);
+	logger.log('sync ios versions? ', cli.ios || false);
 	if (cli.android) {
 		await updateAndroidVersion(packageVersion);
 	}
 
 	if (cli.ios) {
-		await updateIosVersion(packageVersion);
+		let plistFiles;
+		if (cli.plist) {
+			plistFiles = (cli.plist || "").split(",") || [];
+			plistFiles = plistFiles.map((f)=>f.trim());
+		} else {
+			plistFiles = [];
+		}
+
+		logger.log({plistFiles});
+		await updateIosVersion(packageVersion, plistFiles);
 	}
 }
 

--- a/src/modules/ios.js
+++ b/src/modules/ios.js
@@ -7,12 +7,10 @@ logger.state = {isEnabled: true};
 // Path to the Info.plist file which contains the version number for iOS Apps
 export const iosInfoPlistPath = './ios/App/App/Info.plist';
 
-export async function updateIosVersion(newVersionString) {
+export async function updateIosVersion(newVersionString, plist=[]) {
 	logger.log('Updating iOS App Version...');
 
-	const plistObject = parsePlistFileSync(iosInfoPlistPath);
 	const [versionWithoutPrerelease, prereleaseVersion] = newVersionString.split('-');
-
 	if (prereleaseVersion !== undefined) {
 		logger.warn(`
 		This package has a prerelease version defined. 
@@ -20,9 +18,17 @@ export async function updateIosVersion(newVersionString) {
 		THE PRERELEASE VERSION WILL BE IGNORED!`);
 	}
 
-	plistObject.CFBundleShortVersionString = versionWithoutPrerelease;
-	plistObject.CFBundleVersion = versionWithoutPrerelease;
-
-	writePlistFileSync(iosInfoPlistPath, plistObject);
+	// Join additional plist files (incase of additional targets like AppClips)
+	const plistPaths = [iosInfoPlistPath, ...plist];
+	
+	for (let path of plistPaths) {
+		logger.log("Updating file " + path);
+		const plistObject = parsePlistFileSync(path);
+	
+		plistObject.CFBundleShortVersionString = versionWithoutPrerelease;
+		plistObject.CFBundleVersion = versionWithoutPrerelease;
+	
+		writePlistFileSync(path, plistObject);
+	}
 	logger.log('Updating iOS App Version successful. Please commit all pending changes now.');
 }


### PR DESCRIPTION
I noticed for ios services like AppClips: plist versions need to be in sync with each other. I think a flag like
`--plist [files...]` would be useful to have for such cases like this.