### PR TITLE
Update README.md and fix readPackageAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ mainly because this sync is not 1 to 1 possible without assumtions.
 This cli uses an automatic alogrithm to calculate the android versionCode based on the version string from package.json.
 The android versionCode is an ever increasing integer-32 defining the unique version for each app.
 
+## Install
+
+```
+npm i cap-sync-version
+```
+
 ## Required Setup for Android
 
 1. Create a file called `app.properties` under `./android/app/`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import process from 'node:process';
-import {readPackageSync, readPackageAsync} from 'read-pkg';
+import {readPackageSync, readPackage} from 'read-pkg';
 import logdown from 'logdown';
 import {Command} from 'commander';
 import {updateAndroidVersion} from './modules/android.js';
@@ -58,7 +58,7 @@ async function main(cli) {
 		options.ios = true;
 	}
 
-	const projectPackageJson = await readPackageAsync();
+	const projectPackageJson = await readPackage();
 	const packageVersion = projectPackageJson.version;
 
 	logger.log('Updating capacitor project versions to: ', packageVersion);


### PR DESCRIPTION
Fix `SyntaxError: The requested module 'read-pkg' does not provide an export named 'readPackageAsync'`

Add install instructions, npm package name is different from github and it's not trivial to find the package